### PR TITLE
Homepage Link Fix

### DIFF
--- a/Natours/final-after-S06/index.html
+++ b/Natours/final-after-S06/index.html
@@ -27,7 +27,7 @@
 
             <nav class="navigation__nav">
                 <ul class="navigation__list">
-                    <li class="navigation__item"><a href="#" class="navigation__link"><span>01</span>About Natous</a></li>
+                    <li class="navigation__item"><a href="#" class="navigation__link"><span>01</span>About Natours</a></li>
                     <li class="navigation__item"><a href="#" class="navigation__link"><span>02</span>Your benfits</a></li>
                     <li class="navigation__item"><a href="#" class="navigation__link"><span>03</span>Popular tours</a></li>
                     <li class="navigation__item"><a href="#" class="navigation__link"><span>04</span>Stories</a></li>

--- a/Natours/final-after-S06/sass/layout/_navigation.scss
+++ b/Natours/final-after-S06/sass/layout/_navigation.scss
@@ -76,6 +76,9 @@
     }
 
     &__link {
+        pointer-events: none;
+        cursor: default;
+
         &:link,
         &:visited {
             display: inline-block;
@@ -112,6 +115,11 @@
     &__checkbox:checked ~ &__nav {
         opacity: 1;
         width: 100%;
+    }
+
+    &__checkbox:checked ~ &__nav &__list &__item &__link {
+        pointer-events: auto;
+        cursor: pointer;
     }
 
 


### PR DESCRIPTION
Homepage still has clickable navigation links since width of 0 on parent element didn't fully hide the child anchor element due to the padding that was being applied. This fixes it and fixes a typo on the home page.