### PR TITLE
fixing the bug in the menu

### DIFF
--- a/Natours/final-after-S06/sass/layout/_navigation.scss
+++ b/Natours/final-after-S06/sass/layout/_navigation.scss
@@ -59,6 +59,7 @@
         opacity: 0;
         width: 0;
         transition: all .8s cubic-bezier(0.68, -0.55, 0.265, 1.55);
+	visibility: hidden;
     }
 
     &__list {
@@ -112,6 +113,7 @@
     &__checkbox:checked ~ &__nav {
         opacity: 1;
         width: 100%;
+	visibility:visible;
     }
 
 


### PR DESCRIPTION
In the desktop breakpoint, if you position the cursor under the logo, you can see the cursor changing to hand, because the menu items are there, I used display none and after display block, but the solution did not work, because the animation does not work, so I changed for visibility: hidden, and after visibility:visible;

I tested and everything works ok !