### PR TITLE
Changed font-family: 5rem  to font-size: 5rem;

### DIFF
--- a/Natours/final-after-S06/sass/base/_typography.scss
+++ b/Natours/final-after-S06/sass/base/_typography.scss
@@ -25,7 +25,7 @@ body {
         
         @include respond(phone) {
             letter-spacing: 1rem;
-            font-family: 5rem;
+            font-size: 5rem;
         }
         /*
         animation-delay: 3s;


### PR DESCRIPTION
# Issue

In typography.scss the class .heading-primary--main media query for phone contains the attribute  font-family: 5rem;   

## Solution 
I replaced font-family: 5rem with font-size: 5rem. Now the property is being read by the browser.


PS.
Thanks for the amazing course and content! Hope this helps.