### PR TITLE
Changing padding of the heading of about section

### DIFF
--- a/Natours/final-after-S06/sass/pages/_home.scss
+++ b/Natours/final-after-S06/sass/pages/_home.scss
@@ -4,7 +4,7 @@
     margin-top: -20vh;
 
     @include respond(tab-port) {
-        padding: 20rem 0;
+        padding: 25rem 0;
     }
 }
 


### PR DESCRIPTION
I've changed the padding of the heading of about section from 20rem to 25rem, Because you can see screen, less than 600px, the heading of about section & the header section has no padding in between.
Thanks,